### PR TITLE
Configuration to debug with VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "pwa-chrome",
+            "request": "launch",
+            "name": "Launch Chrome against localhost",
+            "url": "http://localhost:8080",
+            "webRoot": "${workspaceFolder}"
+        },
+        {
+            "type": "pwa-chrome",
+            "request": "attach",
+            "name": "Attach to Cypress",
+            "port": 9222,
+            "url": "http://localhost*",
+            "webRoot": "${workspaceFolder}",
+            "sourceMaps": true,
+            "skipFiles": [
+              "cypress_runner.js",
+            ]
+          }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -5,13 +5,19 @@
   "main": "index.js",
   "dependencies": {
     "cypress": "^5.0.0",
+    "npm-run-all": "^4.1.5",
+    "run-p": "0.0.0",
     "typescript": "^4.0.2"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "cross-env": "^7.0.2"
+  },
   "scripts": {
-    "tests": ".\\node_modules\\.bin\\cypress run",
     "test:login": ".\\node_modules\\.bin\\cypress run --spec 'cypress/integration/login/*'",
-    "test:login:chrome": ".\\node_modules\\.bin\\cypress run --spec 'cypress/integration/login/*' --headless --browser chrome"
+    "test:login:chrome": ".\\node_modules\\.bin\\cypress run --spec 'cypress/integration/login/*' --headless --browser chrome",
+    "cypress:open": ".\\node_modules\\.bin\\cypress open",
+    "cypress:run": ".\\node_modules\\.bin\\cypress run",
+    "dev": "cross-env BROWSER=none CYPRESS_REMOTE_DEBUGGING_PORT=9222 node_modules\\.bin\\run-p cypress:open"
   },
   "author": "Yhasmina",
   "license": "ISC"


### PR DESCRIPTION

I add the configuration for debugging, but it's better to use Chrome DevTools.

With this configuration, you can only debug the production code called by the test code, but not the test code.
If you want to debug your test code, you must add the command "debugger;" or the ".debug ()" function, but this only writes to the console ...

**Best for debugging is to use Chrome DevTools.**